### PR TITLE
Add browser smoke tests for critical site flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,8 @@ jobs:
         run: |
           npm ci
           pip install -r requirements-dev.txt
+          npx playwright install --with-deps chromium
       - name: Run repository checks
         run: bundle exec rake check
+      - name: Run browser smoke tests
+        run: npm run test:e2e

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           pip install -r requirements-dev.txt
           npm ci
+          npx playwright install --with-deps chromium
 
       - name: Guardian - Lint YAML
         run: yamllint .
@@ -73,6 +74,9 @@ jobs:
         run: |
           bundle exec htmlproofer ./_site --disable-external --allow-hash-href --swap-urls "/ag-comp-arith-geom/:/" --no-check-internal-hash --no-enforce-https
           python3 scripts/check_generated_site.py
+
+      - name: Browser smoke tests
+        run: npm run test:e2e
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,6 @@ test/
 tests/
 spec/
 coverage/
+playwright-report/
+test-results/
 pagescmsdocs/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This website is built with **Jekyll** and hosted on **GitHub Pages**.
    ```bash
    bundle install
    npm ci
+   npx playwright install chromium
    python3 -m venv .venv
    .venv/bin/pip install -r requirements-dev.txt
    ```
@@ -64,6 +65,7 @@ This website is built with **Jekyll** and hosted on **GitHub Pages**.
 4. **Run the same checks used in CI:**
    ```bash
    bundle exec rake check
+   npm run test:e2e
    ```
 
 ### Maintenance Scripts

--- a/e2e/site-smoke.spec.js
+++ b/e2e/site-smoke.spec.js
@@ -1,0 +1,73 @@
+const { expect, test } = require('@playwright/test');
+
+const criticalRoutes = [
+  { label: '/', path: './' },
+  { label: '/members/', path: 'members/' },
+  { label: '/publications/', path: 'publications/' },
+  { label: '/teaching/', path: 'teaching/' },
+  { label: '/research/', path: 'research/' },
+  { label: '/links/', path: 'links/' },
+  { label: '/contact/', path: 'contact/' },
+];
+
+for (const route of criticalRoutes) {
+  test(`${route.label} renders the shared page shell`, async ({ page }) => {
+    const response = await page.goto(route.path);
+
+    expect(response?.ok()).toBeTruthy();
+    await expect(page).toHaveTitle(/AG Computational Arithmetic Geometry/);
+    await expect(page.locator('.header-main')).toBeVisible();
+    await expect(page.locator('#main-content')).toBeVisible();
+    await expect(page.locator('.footer')).toBeVisible();
+
+    const emptyResourceAttributes = await page
+      .locator('a[href=""], img[src=""], script[src=""]')
+      .count();
+    expect(emptyResourceAttributes).toBe(0);
+  });
+}
+
+test('CMS-backed overview pages contain generated entries', async ({ page }) => {
+  await page.goto('members/');
+  expect(await page.locator('.member-card').count()).toBeGreaterThan(0);
+
+  await page.goto('publications/');
+  expect(await page.locator('.publication-card').count()).toBeGreaterThan(0);
+
+  await page.goto('teaching/');
+  expect(await page.locator('.course-card').count()).toBeGreaterThan(0);
+});
+
+test.describe('mobile navigation', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('opens, exposes state, and closes with Escape', async ({ page }) => {
+    await page.goto('./');
+
+    const toggle = page.locator('.nav-toggle');
+    const sidebar = page.locator('#sidebar-navigation');
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(sidebar).toHaveAttribute('aria-hidden', 'false');
+
+    await page.keyboard.press('Escape');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+test('representative generated detail pages resolve', async ({ page }) => {
+  await page.goto('members/');
+  const memberPath = await page.locator('.member-card a').first().getAttribute('href');
+  expect(memberPath).toBeTruthy();
+  await page.goto(memberPath);
+  await expect(page.locator('.member-profile-page')).toBeVisible();
+
+  await page.goto('publications/');
+  const publicationPath = await page.locator('.publication-card a').first().getAttribute('href');
+  expect(publicationPath).toBeTruthy();
+  await page.goto(publicationPath);
+  await expect(page.locator('.publication-page')).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "prettier": "^2.8.8",
         "stylelint": "^16.26.1",
         "stylelint-config-standard-scss": "^16.0.0"
@@ -247,6 +248,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ajv": {
@@ -614,6 +631,21 @@
       "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -1094,6 +1126,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "audit": "npm audit --audit-level=high",
     "check": "npm run lint:styles && npm run audit",
-    "lint:styles": "stylelint \"**/*.scss\""
+    "lint:styles": "stylelint \"**/*.scss\"",
+    "test:e2e": "playwright test"
   },
   "engines": {
     "node": ">=20"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "prettier": "^2.8.8",
     "stylelint": "^16.26.1",
     "stylelint-config-standard-scss": "^16.0.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4000/ag-comp-arith-geom/',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'bundle exec jekyll serve --no-watch --host 127.0.0.1 --port 4000',
+    url: 'http://127.0.0.1:4000/ag-comp-arith-geom/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## What changed

- adds Playwright browser testing with a managed Chromium version
- exercises all seven primary routes through the real Jekyll development server
- verifies the shared header, main content, footer, titles, and resource attributes
- checks that CMS-backed member, publication, and teaching entries render
- follows representative generated member and publication detail links
- verifies mobile navigation state and Escape-key behavior
- runs the browser suite in GitHub Actions
- documents local browser setup and execution

## Why

Static HTML checks cannot catch browser-only regressions such as broken navigation state, incorrect base URLs, or generated detail links that fail after client-side behavior runs. This adds focused end-to-end protection without changing the site itself.

## PR dependency

This is a stacked PR targeting `chore/repository-improvements` because the tests rely on the reliability and navigation fixes in #62. After #62 merges, this PR can be retargeted to `main`.

## User and CMS impact

Testing and CI only. No UI, Pages CMS schema, CMS-authored content, generated copy, or uploaded media is changed.

## Verification

- 10 Playwright tests passed locally
- desktop critical-route smoke tests passed
- CMS-backed overview and detail-page tests passed
- mobile navigation keyboard test passed
- `bundle exec rake check` passed
- npm audit reports zero vulnerabilities
