### PR TITLE
Add safe Pages CMS validation action

### DIFF
--- a/.github/workflows/pages-cms-validate.yml
+++ b/.github/workflows/pages-cms-validate.yml
@@ -1,0 +1,46 @@
+name: Validate Pages CMS changes
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: Pages CMS payload as JSON
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-cms-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout selected revision
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install validation dependencies
+        run: |
+          npm ci
+          pip install -r requirements-dev.txt
+      - name: Validate site
+        run: bundle exec rake check

--- a/.pages.yml
+++ b/.pages.yml
@@ -1,6 +1,29 @@
 # This file is used to configure the PagesCMS interface.
 # For more information, see: https://pagescms.org/docs/configuration/
 
+settings:
+  content:
+    # Keep data keys that are not currently exposed as CMS fields.
+    merge: true
+  commit:
+    identity: app
+    templates:
+      create: "content(create): {path}"
+      update: "content(update): {path}"
+      delete: "content(delete): {path}"
+      rename: "content(rename): {oldPath} -> {newPath}"
+
+actions:
+  - name: "validate-site"
+    label: "Validate site"
+    workflow: "pages-cms-validate.yml"
+    ref: "current"
+    cancelable: true
+    confirm:
+      title: "Validate the site?"
+      message: "Run the repository checks without deploying or changing content."
+      button: "Validate"
+
 media:
   input: "assets/uploads"
   output: "/assets/uploads"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -75,6 +75,60 @@ class Validator:
             if size_mb > 2:
                 self.warning(f"{relative}: large file ({size_mb:.2f} MB)")
 
+    def validate_pages_cms(self) -> None:
+        config_path = ROOT / ".pages.yml"
+        try:
+            with config_path.open(encoding="utf-8") as stream:
+                config = yaml.safe_load(stream)
+        except (OSError, UnicodeError, yaml.YAMLError) as error:
+            self.error(f".pages.yml: cannot be read: {error}")
+            return
+
+        config = self.require_mapping(config, ".pages.yml")
+        if config is None:
+            return
+
+        content = self.require_list(config.get("content"), ".pages.yml.content")
+        if content is not None:
+            names: set[str] = set()
+            for index, raw_item in enumerate(content, start=1):
+                location = f".pages.yml.content[{index}]"
+                item = self.require_mapping(raw_item, location)
+                if item is None:
+                    continue
+                name = item.get("name")
+                self.require_text(name, f"{location}.name")
+                if isinstance(name, str):
+                    if name in names:
+                        self.error(f"{location}.name: duplicate content name {name!r}")
+                    names.add(name)
+                path = item.get("path")
+                self.require_text(path, f"{location}.path")
+                if isinstance(path, str) and not (ROOT / path).is_file():
+                    self.error(f"{location}.path: file does not exist: {path}")
+
+        actions = self.require_list(config.get("actions", []), ".pages.yml.actions")
+        if actions is not None:
+            for index, raw_action in enumerate(actions, start=1):
+                location = f".pages.yml.actions[{index}]"
+                action = self.require_mapping(raw_action, location)
+                if action is None:
+                    continue
+                workflow = action.get("workflow")
+                self.require_text(workflow, f"{location}.workflow")
+                if not isinstance(workflow, str):
+                    continue
+                workflow_name = Path(workflow)
+                if workflow_name.name != workflow or workflow_name.suffix not in {
+                    ".yml",
+                    ".yaml",
+                }:
+                    self.error(f"{location}.workflow: expected a workflow filename")
+                    continue
+                workflow_path = ROOT / ".github" / "workflows" / workflow
+                if not workflow_path.is_file():
+                    self.error(f"{location}.workflow: file does not exist: {workflow}")
+
     def validate_members(self) -> None:
         data = self.require_mapping(self.load_yaml("members.yml"), "_data/members.yml")
         if data is None:
@@ -217,6 +271,7 @@ class Validator:
                     )
 
     def run(self) -> int:
+        self.validate_pages_cms()
         self.validate_uploads()
         self.validate_members()
         self.validate_publications()


### PR DESCRIPTION
## Summary

- add a validation-only action to the Pages CMS Actions area
- preserve unmanaged YAML keys when editors save structured content
- use consistent future Pages CMS commit messages
- validate CMS content paths and referenced workflows in the repository checks
- run the complete repository check suite from the CMS action without deploying or writing content

## Validation

- `bundle exec rake check`
- `python3 -m py_compile scripts/validate.py`
- `.venv/bin/yamllint .pages.yml .github/workflows/pages-cms-validate.yml`
- `git diff --check`

## Notes

This is stacked on #62. It does not change website UI or any editor-added content. The new action becomes usable after this workflow exists on the default branch.