### PR TITLE
Improve accessibility and mobile controls

### DIFF
--- a/_includes/layout/header.liquid
+++ b/_includes/layout/header.liquid
@@ -1,6 +1,6 @@
 <header class="header-main">
   <div class="header-content-wrapper">
-    <a class="brand" href="{{ site.baseurl }}/">
+    <a class="brand" href="{{ site.baseurl }}/" aria-label="{{ site.title | escape }} — {{ site.university | escape }}" title="{{ site.title | escape }}">
       <div class="brand-title">{{ site.title | escape }}</div>
       <div class="university-name">{{ site.university | escape }}</div>
     </a>

--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -17,6 +17,7 @@
 
   <!-- Body -->
   <body class="d-flex flex-column min-vh-100 {% if site.navbar_fixed %}fixed-top-nav{% endif %} {% unless site.footer_fixed %}sticky-bottom-footer{% endunless %}">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <!-- Header -->
     {% include layout/header.liquid %}
 

--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -19,6 +19,8 @@ layout: default
     </div>
   </div>
 </div>
+{% elsif page.url != '/' and page.has_content_h1 != true %}
+  <h1 class="visually-hidden">{{ page.title | default: page.name | escape }}</h1>
 {% endif %}
 
 <article class="page-article tex2jax_process">

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -5,6 +5,7 @@ nav: true
 nav_order: 1
 order: 100
 show_title: false
+has_content_h1: true
 title: Home
 description: "Official website of the Computational Arithmetic Geometry research group at Heidelberg University."
 about_title: "About Our Research Group"

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1593,3 +1593,32 @@ table {
     background-color: rgba(0, 0, 0, 0.02);
   }
 }
+/* Keyboard-only shortcut that remains outside the visual layout until focused. */
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 2000;
+  padding: 0.75rem 1rem;
+  background: var(--global-bg-color, #fff);
+  color: var(--global-text-color, #111) !important;
+  border: 2px solid var(--primary, #c22032);
+  border-radius: 0.375rem;
+  transform: translateY(-150%);
+  transition: none;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -124,11 +124,20 @@
     flex-shrink: 0;
 
     @media (max-width: 1199.98px) {
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       background: none;
       border: none;
       padding: 0.5rem;
+      min-width: 44px;
+      min-height: 44px;
       cursor: pointer;
+
+      &:focus-visible {
+        outline: 2px solid white;
+        outline-offset: 2px;
+      }
 
       .nav-toggle-icon {
         display: block;

--- a/_teaching/index.md
+++ b/_teaching/index.md
@@ -75,14 +75,14 @@ description: "An overview of our courses, seminars, and lectures, organized by s
           {% assign highlight_class = "highlight-current" %}
         {% endif %}
         <div class="semester-section {{ highlight_class | strip }}">
-          <h4 class="semester-title">{{ semester_title | escape }}</h4>
+          <h2 class="semester-title">{{ semester_title | escape }}</h2>
           {% for course in semester.courses %}
             <div class="course-card position-relative">
-              <h5 class="course-title">
+              <h3 class="course-title">
                 {% assign course_slug = course.title | slugify: "latin" %}
                 {% assign semester_slug = semester_title | slugify: "latin" %}
                 <a href="{{ '/teaching/' | append: year_data.year | append: '/' | append: semester_slug | append: '/' | append: course_slug | append: '/' | relative_url }}" class="text-decoration-none text-dark stretched-link">{{ course.title | escape }}</a>
-              </h5>
+              </h3>
               {% if course.instructor %}
                 <p class="course-instructor"><i class="fas fa-user-tie"></i> {{ course.instructor | escape }}</p>
               {% endif %}

--- a/scripts/check_generated_site.py
+++ b/scripts/check_generated_site.py
@@ -23,6 +23,26 @@ def main() -> int:
         relative = path.relative_to(ROOT)
         soup = BeautifulSoup(path.read_text(encoding="utf-8"), "html.parser")
 
+        if soup.html is None:
+            continue
+
+        is_redirect = soup.select_one('meta[http-equiv="refresh"]') is not None
+        if not is_redirect and soup.select_one("main h1, [role='main'] h1") is None:
+            errors.append(f"{relative}: main content is missing an h1")
+
+        ids = [str(element["id"]) for element in soup.select("[id]")]
+        duplicate_ids = sorted({value for value in ids if ids.count(value) > 1})
+        for duplicate_id in duplicate_ids:
+            errors.append(f"{relative}: duplicate id {duplicate_id!r}")
+
+        for image in soup.find_all("img"):
+            if not image.has_attr("alt"):
+                errors.append(f"{relative}: image is missing alt text")
+
+        for frame in soup.find_all("iframe"):
+            if not str(frame.get("title", "")).strip():
+                errors.append(f"{relative}: iframe is missing a title")
+
         for tag, attribute in (("a", "href"), ("img", "src"), ("script", "src")):
             for element in soup.find_all(tag):
                 if element.has_attr(attribute) and not str(element[attribute]).strip():


### PR DESCRIPTION
## Summary

- add a keyboard-visible skip link to main content
- guarantee a main heading on pages whose visual title is intentionally hidden
- correct Teaching heading levels while preserving existing typography
- expand the mobile navigation target to 46×44 CSS pixels
- expose the complete truncated mobile brand name to assistive technology
- respect reduced-motion preferences
- validate main headings, duplicate IDs, image alt text, and iframe titles after every build

## Impact

The normal visual layout and CMS-authored content are unchanged. The skip link appears only when keyboard-focused.

## Validation

- full repository checks passed before the final CSS-only adjustment
- SCSS lint, Jekyll build, generated-site, SEO, and performance checks passed after it
- six primary routes have one main h1, a 46×44 mobile menu target, and zero horizontal overflow at 375px

## Stack

This PR is stacked on #68.