### PR TITLE
Harden dependencies and external resources

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,32 @@
+name: Dependency audit
+
+on:
+  pull_request:
+  schedule:
+    - cron: "19 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Audit Ruby dependencies
+        run: bundle exec bundler-audit check --update
+      - name: Audit JavaScript dependencies
+        run: npm audit --audit-level=high

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "csv"
 gem "base64"
 
 group :development do
+  gem "bundler-audit", "~> 0.9"
   gem "html-proofer", "~> 5.0"
   gem "minitest", "~> 5.0"
   gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
     async (2.37.0)
       console (~> 1.29)
@@ -17,6 +17,9 @@ GEM
       latex-decode (~> 0.0)
       racc (~> 1.7)
     bigdecimal (3.2.2)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     citeproc (1.1.0)
       date
       forwardable
@@ -29,7 +32,7 @@ GEM
       csl (~> 2.0)
       observer (< 1.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.8)
     console (1.34.3)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -107,7 +110,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.12.2)
+    json (2.21.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -138,14 +141,14 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rouge (4.5.2)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
@@ -156,6 +159,7 @@ GEM
     stringio (3.1.7)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thor (1.5.0)
     time (0.4.1)
       date
     traces (0.18.2)
@@ -164,7 +168,7 @@ GEM
     typhoeus (1.6.0)
       ethon (>= 0.18.0)
     unicode-display_width (2.6.0)
-    uri (1.0.3)
+    uri (1.1.1)
     webrick (1.9.1)
     yell (2.2.2)
     zeitwerk (2.8.3)
@@ -174,6 +178,7 @@ PLATFORMS
 
 DEPENDENCIES
   base64
+  bundler-audit (~> 0.9)
   csv
   html-proofer (~> 5.0)
   http_parser.rb (~> 0.6.0)

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,7 @@ task site: :build do
   sh "bundle exec htmlproofer ./_site --disable-external --allow-hash-href " \
      "--swap-urls '/ag-comp-arith-geom/:/' --no-check-internal-hash --no-enforce-https"
   sh "#{python} scripts/check_generated_site.py"
+  sh "#{python} scripts/check_external_resources.py"
 end
 
 desc "Run all repository checks"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not disclose suspected vulnerabilities in a public issue. Use the
+repository's **Security** tab to submit a private vulnerability report. If that
+option is unavailable, email `arithgeo@iwr.uni-heidelberg.de` with the subject
+`Website security report`.
+
+Include the affected URL or component, reproduction steps, likely impact, and
+any suggested mitigation. Do not include unrelated personal data or attempt to
+access, alter, or remove other people's content.
+
+Maintainers should acknowledge a report within seven days. Remediation and
+disclosure timing depend on severity and the availability of upstream fixes.
+
+## Supported version
+
+The deployed version from the default branch is supported. Older deployments,
+forks, and unmerged branches are not maintained security releases.
+
+## Deployment headers
+
+GitHub Pages does not provide repository-level configuration for HTTP response
+headers. If the site is later served through a configurable CDN or proxy, add a
+tested Content Security Policy, Permissions Policy, HSTS, and MIME-sniffing
+protection there. A strict Content Security Policy must account for the site's
+inline structured data and scripts before enforcement; an untested policy can
+break navigation, mathematics, analytics, or CMS-managed embeds.

--- a/_includes/layout/head.liquid
+++ b/_includes/layout/head.liquid
@@ -31,8 +31,8 @@
 <!-- Vendor CSS -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.3.2/mdb.min.css" rel="stylesheet">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.3.2/mdb.min.css" rel="stylesheet" integrity="sha384-kj1RBJ7aqGUnavWQDbYyovF5HQGHlvNf6SZ2CfaCNkoBJBEux2JXFCXqGZTAYENh" crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@v1.9.4/css/academicons.min.css" integrity="sha384-cxs0Bj979VdNByRZzAJ2KJWG8vH/kG7fwWZAIZW3Tmsw0rAuP/pu3I3LitFWEs18" crossorigin="anonymous" referrerpolicy="no-referrer">
 
 
 <!-- Google Fonts - Modern Academic Style (similar to Heidelberg University) -->
@@ -52,7 +52,7 @@
 
 {% if page.toc and page.toc.sidebar %}
   <!-- Sidebar Table of Contents -->
-  <link defer href="https://cdn.jsdelivr.net/gh/afeld/bootstrap-toc@v1.0.1/dist/bootstrap-toc.min.css" rel="stylesheet">
+  <link defer href="https://cdn.jsdelivr.net/gh/afeld/bootstrap-toc@v1.0.1/dist/bootstrap-toc.min.css" rel="stylesheet" integrity="sha384-oJyFk/zeMJXNIGMVvmH262FT6dbSYss66WJHHgp1RlUk4/LfONQTzkAsHHwfcqat" crossorigin="anonymous" referrerpolicy="no-referrer">
 {% endif %}
 
 <!-- Styles -->
@@ -104,6 +104,7 @@
 
 <!-- Theme Color for Mobile Browsers -->
 <meta name="theme-color" content="#C22032" id="theme-color-meta">
+<meta name="referrer" content="strict-origin-when-cross-origin">
 
 <!-- Enhanced Meta Tags -->
 <meta name="application-name" content="AG Computational Arithmetic Geometry">
@@ -126,7 +127,7 @@
   };
 </script>
 
-<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-mml-chtml.js" integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="{{ '/assets/js/components/mathjax-setup.js' | relative_url | bust_file_cache }}"></script>
 
 {% if site.enable_darkmode %}

--- a/_includes/scripts/scripts.liquid
+++ b/_includes/scripts/scripts.liquid
@@ -1,6 +1,6 @@
 <!-- Vendor JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.3.2/mdb.umd.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.3.2/mdb.umd.min.js" integrity="sha384-TGRlbFTmiVIUuSy+b/aj9mHaUTABC3gid02pJimnu14vfLMvOzODXgRmw03nf7vs" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {% if site.third_party_libraries.jquery.url.js %}
   <script src="{{ site.third_party_libraries.jquery.url.js }}" integrity="{{ site.third_party_libraries.jquery.integrity.js }}" crossorigin="anonymous"></script>
 {% endif %}
@@ -58,7 +58,7 @@
 
 {% if page.toc and site.third_party_libraries.jquery.url.js %}
   <!-- Bootstrap Table of Contents -->
-  <script src="https://cdn.jsdelivr.net/gh/afeld/bootstrap-toc@v1.0.1/dist/bootstrap-toc.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/afeld/bootstrap-toc@v1.0.1/dist/bootstrap-toc.min.js" integrity="sha384-OGf04BRlCdmgZXHhCupHT3BIkznbahjfhX8DKSIEXyU9PvSO0/8iMiiVJPcA5vi7" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
     $(function () {
       var navSelector = '#toc';

--- a/scripts/check_external_resources.py
+++ b/scripts/check_external_resources.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Check generated pages for basic third-party resource protections."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SITE = ROOT / "_site"
+INTEGRITY_EXEMPT_HOSTS = {"fonts.googleapis.com", "fonts.gstatic.com"}
+
+
+def main() -> int:
+    errors: set[str] = set()
+    pages = sorted(SITE.rglob("*.html"))
+    if not pages:
+        print("[ERROR] _site has no HTML files; build the site first.")
+        return 1
+
+    for page in pages:
+        soup = BeautifulSoup(page.read_text(encoding="utf-8"), "html.parser")
+        if soup.head is None:
+            continue
+        if not soup.find("meta", attrs={"name": "referrer"}):
+            errors.add(f"{page.relative_to(SITE)}: missing referrer policy")
+
+        resources = list(soup.find_all("script", src=True))
+        resources.extend(
+            link
+            for link in soup.find_all("link", href=True)
+            if "stylesheet" in (link.get("rel") or [])
+        )
+        for element in resources:
+            url = element.get("src") or element.get("href")
+            parsed = urlparse(url)
+            if parsed.scheme not in {"http", "https"}:
+                continue
+            if parsed.hostname in INTEGRITY_EXEMPT_HOSTS:
+                continue
+            if not element.get("integrity"):
+                errors.add(f"external resource lacks integrity metadata: {url}")
+            if element.get("crossorigin") != "anonymous":
+                errors.add(f"external resource lacks crossorigin=anonymous: {url}")
+
+    if errors:
+        for error in sorted(errors):
+            print(f"[ERROR] {error}")
+        return 1
+
+    print(f"External-resource validation passed across {len(pages)} pages.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- patch vulnerable Ruby transitive dependencies and add Bundler Audit alongside npm audit
- pin remaining core third-party URLs and require Subresource Integrity/cross-origin metadata
- validate generated external resources and apply a referrer policy
- document private vulnerability reporting and the GitHub Pages response-header limitation

## Security results
Bundler Audit originally detected vulnerable locked versions of addressable, concurrent-ruby, json, rexml, and uri. All are updated to patched versions; both Ruby and npm audits now report zero known vulnerabilities.

## Validation
- bundle exec bundler-audit check --update
- npm audit --audit-level=high
- bundle exec rake check
- browser smoke test at 375px on home, publications, research, and teaching: HTTP 200, no horizontal overflow, no console/page/request failures

AI-assisted implementation; human review is still required before merging.