### PR TITLE
Automate and safeguard Pages CMS validation

### DIFF
--- a/.github/workflows/pages-cms-validate.yml
+++ b/.github/workflows/pages-cms-validate.yml
@@ -1,11 +1,18 @@
-name: Validate Pages CMS changes
+name: Validate CMS content
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - ".pages.yml"
+      - "_data/**"
+      - "assets/uploads/**"
   workflow_dispatch:
     inputs:
       payload:
-        description: Pages CMS payload as JSON
-        required: true
+        description: Optional Pages CMS payload as JSON
+        required: false
+        default: "{}"
         type: string
 
 permissions:

--- a/.github/workflows/pages-cms-validate.yml
+++ b/.github/workflows/pages-cms-validate.yml
@@ -1,0 +1,46 @@
+name: Validate Pages CMS changes
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: Pages CMS payload as JSON
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-cms-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout selected revision
+        uses: actions/checkout@v7
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install validation dependencies
+        run: |
+          npm ci
+          pip install -r requirements-dev.txt
+      - name: Validate site
+        run: bundle exec rake check

--- a/.pages.yml
+++ b/.pages.yml
@@ -13,17 +13,6 @@ settings:
       delete: "content(delete): {path}"
       rename: "content(rename): {oldPath} -> {newPath}"
 
-actions:
-  - name: "validate-site"
-    label: "Validate site"
-    workflow: "pages-cms-validate.yml"
-    ref: "current"
-    cancelable: true
-    confirm:
-      title: "Validate the site?"
-      message: "Run the repository checks without deploying or changing content."
-      button: "Validate"
-
 media:
   input: "assets/uploads"
   output: "/assets/uploads"
@@ -33,6 +22,10 @@ content:
     label: "Home Page"
     path: "_data/home.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "hero"
         label: "Hero Section"
@@ -62,6 +55,10 @@ content:
     label: "Research Page"
     path: "_data/research.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "research_areas"
         label: "Research Areas"
@@ -79,6 +76,10 @@ content:
     label: "Publications"
     path: "_data/publications.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "publications"
         label: "Publications List"
@@ -141,6 +142,10 @@ content:
     label: "Teaching"
     path: "_data/teaching.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "courses"
         label: "Courses by Year"
@@ -200,6 +205,10 @@ content:
     label: "Members"
     path: "_data/members.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "sections"
         label: "Member Sections"
@@ -309,6 +318,10 @@ content:
     label: "Links Page"
     path: "_data/links.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "groups"
         label: "Link Groups"
@@ -335,6 +348,10 @@ content:
     label: "Contact Page"
     path: "_data/contact.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "address"
         label: "Address"
@@ -387,6 +404,10 @@ content:
     label: "Shortlinks"
     path: "_data/shortlinks.yml"
     type: "file"
+    operations:
+      create: false
+      rename: false
+      delete: false
     fields:
       - name: "shortlinks"
         label: "Redirects"

--- a/.pages.yml
+++ b/.pages.yml
@@ -1,6 +1,29 @@
 # This file is used to configure the PagesCMS interface.
 # For more information, see: https://pagescms.org/docs/configuration/
 
+settings:
+  content:
+    # Keep data keys that are not currently exposed as CMS fields.
+    merge: true
+  commit:
+    identity: app
+    templates:
+      create: "content(create): {path}"
+      update: "content(update): {path}"
+      delete: "content(delete): {path}"
+      rename: "content(rename): {oldPath} -> {newPath}"
+
+actions:
+  - name: "validate-site"
+    label: "Validate site"
+    workflow: "pages-cms-validate.yml"
+    ref: "current"
+    cancelable: true
+    confirm:
+      title: "Validate the site?"
+      message: "Run the repository checks without deploying or changing content."
+      button: "Validate"
+
 media:
   input: "assets/uploads"
   output: "/assets/uploads"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -75,6 +75,60 @@ class Validator:
             if size_mb > 2:
                 self.warning(f"{relative}: large file ({size_mb:.2f} MB)")
 
+    def validate_pages_cms(self) -> None:
+        config_path = ROOT / ".pages.yml"
+        try:
+            with config_path.open(encoding="utf-8") as stream:
+                config = yaml.safe_load(stream)
+        except (OSError, UnicodeError, yaml.YAMLError) as error:
+            self.error(f".pages.yml: cannot be read: {error}")
+            return
+
+        config = self.require_mapping(config, ".pages.yml")
+        if config is None:
+            return
+
+        content = self.require_list(config.get("content"), ".pages.yml.content")
+        if content is not None:
+            names: set[str] = set()
+            for index, raw_item in enumerate(content, start=1):
+                location = f".pages.yml.content[{index}]"
+                item = self.require_mapping(raw_item, location)
+                if item is None:
+                    continue
+                name = item.get("name")
+                self.require_text(name, f"{location}.name")
+                if isinstance(name, str):
+                    if name in names:
+                        self.error(f"{location}.name: duplicate content name {name!r}")
+                    names.add(name)
+                path = item.get("path")
+                self.require_text(path, f"{location}.path")
+                if isinstance(path, str) and not (ROOT / path).is_file():
+                    self.error(f"{location}.path: file does not exist: {path}")
+
+        actions = self.require_list(config.get("actions", []), ".pages.yml.actions")
+        if actions is not None:
+            for index, raw_action in enumerate(actions, start=1):
+                location = f".pages.yml.actions[{index}]"
+                action = self.require_mapping(raw_action, location)
+                if action is None:
+                    continue
+                workflow = action.get("workflow")
+                self.require_text(workflow, f"{location}.workflow")
+                if not isinstance(workflow, str):
+                    continue
+                workflow_name = Path(workflow)
+                if workflow_name.name != workflow or workflow_name.suffix not in {
+                    ".yml",
+                    ".yaml",
+                }:
+                    self.error(f"{location}.workflow: expected a workflow filename")
+                    continue
+                workflow_path = ROOT / ".github" / "workflows" / workflow
+                if not workflow_path.is_file():
+                    self.error(f"{location}.workflow: file does not exist: {workflow}")
+
     def validate_members(self) -> None:
         data = self.require_mapping(self.load_yaml("members.yml"), "_data/members.yml")
         if data is None:
@@ -243,6 +297,7 @@ class Validator:
                 self.error(f"{location}.map_url: must not contain secret parameter(s): {names}")
 
     def run(self) -> int:
+        self.validate_pages_cms()
         self.validate_uploads()
         self.validate_members()
         self.validate_publications()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -16,6 +16,8 @@ ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = ROOT / "_data"
 UPLOADS_DIR = ROOT / "assets" / "uploads"
 SAFE_FILENAME = re.compile(r"^[A-Za-z0-9._-]+$")
+UPLOAD_EXTENSIONS = {".gif", ".jpeg", ".jpg", ".pdf", ".png", ".svg", ".webp"}
+LEGACY_UPLOAD_MISMATCHES = {"assets/uploads/Boeckle.pdf"}
 
 
 class Validator:
@@ -65,15 +67,36 @@ class Validator:
             if not path.is_file():
                 continue
             relative = path.relative_to(ROOT)
+            relative_name = relative.as_posix()
             if not SAFE_FILENAME.fullmatch(path.name):
                 self.error(f"{relative}: filename contains unsafe characters")
+            if path.suffix.casefold() not in UPLOAD_EXTENSIONS:
+                self.error(f"{relative}: unsupported upload type {path.suffix or '(none)'}")
             try:
-                size_mb = path.stat().st_size / (1024 * 1024)
+                size = path.stat().st_size
             except OSError as error:
                 self.warning(f"{relative}: cannot read file size: {error}")
                 continue
-            if size_mb > 2:
-                self.warning(f"{relative}: large file ({size_mb:.2f} MB)")
+            if size == 0:
+                self.error(f"{relative}: uploaded file is empty")
+                continue
+            size_mb = size / (1024 * 1024)
+            if size_mb > 5:
+                self.error(f"{relative}: upload exceeds the 5 MB limit ({size_mb:.2f} MB)")
+
+            if path.suffix.casefold() == ".pdf":
+                try:
+                    is_pdf = path.read_bytes()[:5] == b"%PDF-"
+                except OSError as error:
+                    self.warning(f"{relative}: cannot inspect file type: {error}")
+                    continue
+                if not is_pdf and relative_name in LEGACY_UPLOAD_MISMATCHES:
+                    self.warning(
+                        f"{relative}: legacy file is not a PDF; replace it through a "
+                        "content-reviewed asset change"
+                    )
+                elif not is_pdf:
+                    self.error(f"{relative}: file content does not match its .pdf extension")
 
     def validate_pages_cms(self) -> None:
         config_path = ROOT / ".pages.yml"
@@ -106,6 +129,17 @@ class Validator:
                 self.require_text(path, f"{location}.path")
                 if isinstance(path, str) and not (ROOT / path).is_file():
                     self.error(f"{location}.path: file does not exist: {path}")
+                if item.get("type") == "file":
+                    operations = self.require_mapping(
+                        item.get("operations"), f"{location}.operations"
+                    )
+                    if operations is not None:
+                        for operation in ("create", "rename", "delete"):
+                            if operations.get(operation) is not False:
+                                self.error(
+                                    f"{location}.operations.{operation}: expected false "
+                                    "for a protected singleton file"
+                                )
 
         actions = self.require_list(config.get("actions", []), ".pages.yml.actions")
         if actions is not None:


### PR DESCRIPTION
## Summary
- validate Pages CMS content saves automatically when CMS-managed files are pushed to main
- preserve unmanaged YAML keys and use consistent CMS commit messages
- prevent create, rename, and delete operations for protected singleton data files
- reject unsafe filenames, unsupported uploads, empty files, spoofed PDFs, and uploads over 5 MB
- keep the existing Pages deployment gated behind its full build and validation job

## Integration behavior
The manual Pages CMS action was removed after live testing showed the installed Pages CMS GitHub App lacks Actions write permission. Automatic push validation does not depend on that integration permission. The workflow retains an optional GitHub-native manual dispatch after it reaches the default branch.

## Content safety
No CMS content or uploads are deleted or rewritten. The known legacy HTML file named `Boeckle.pdf` remains in place and produces an explicit non-blocking warning for later human review.

## Validation
- `bundle exec rake check`
- `python3 -m py_compile scripts/validate.py`
- `.venv/bin/python -m yamllint .pages.yml .github/workflows/pages-cms-validate.yml`
- `git diff --check`

AI-assisted implementation; human review is still required before merging.