### PR TITLE
Add accessible publication search

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -9,13 +9,31 @@ order: 100
 title: Publications
 description: "Browse the comprehensive list of publications from the Computational Arithmetic Geometry research group, including journal articles, preprints, and books."
 excerpt_separator: ""
+scripts:
+  - /assets/js/publication-search.js
 ---
 
 <div class="publications-container">
-  <div class="search-results-header">
-    <span class="results-count">{{ site.data.publications.publications.size }} results</span>
+  <form class="publication-search" role="search" aria-label="Search publications" novalidate>
+    <label for="publication-search-input">Search publications</label>
+    <div class="publication-search-control">
+      <i class="fas fa-search" aria-hidden="true"></i>
+      <input
+        id="publication-search-input"
+        type="search"
+        inputmode="search"
+        autocomplete="off"
+        placeholder="Title, author, journal, year, status, or MR number"
+        aria-controls="publication-grid"
+        aria-describedby="publication-result-count"
+      >
+      <button type="button" class="publication-search-clear" aria-label="Clear publication search" hidden>Clear</button>
+    </div>
+  </form>
+  <div class="search-results-header" aria-live="polite" aria-atomic="true">
+    <span class="results-count" id="publication-result-count">{{ site.data.publications.publications.size }} publications</span>
   </div>
-  <div class="publication-grid">
+  <div class="publication-grid" id="publication-grid">
     {% assign all_pubs = site.data.publications.publications %}
     {% assign pubs_with_year = all_pubs | where_exp: "item", "item.year != nil and item.year != ''" %}
     {% assign pubs_without_year = all_pubs | where_exp: "item", "item.year == nil or item.year == ''" %}
@@ -96,6 +114,7 @@ excerpt_separator: ""
       </div>
     {% endfor %}
   </div>
+  <p class="publication-search-empty" hidden>No publications match your search.</p>
 
   {% if site.data.publications.software %}
   <div class="software-section mt-5">

--- a/_sass/_publications.scss
+++ b/_sass/_publications.scss
@@ -1,5 +1,79 @@
 @use 'variables' as v;
 
+.publication-search {
+  margin-bottom: 0.5rem;
+
+  label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+  }
+}
+
+.publication-search-control {
+  position: relative;
+
+  > i {
+    position: absolute;
+    top: 50%;
+    left: 0.85rem;
+    color: var(--text-muted);
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
+
+  input {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.65rem 4.75rem 0.65rem 2.5rem;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: v.$radius-sm;
+
+    &:focus-visible {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.publication-search-clear {
+  position: absolute;
+  top: 50%;
+  right: 0.35rem;
+  min-width: 44px;
+  min-height: 34px;
+  padding: 0.3rem 0.6rem;
+  color: var(--primary);
+  background: transparent;
+  border: 0;
+  border-radius: v.$radius-sm;
+  transform: translateY(-50%);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--bg-secondary);
+  }
+}
+
+.search-results-header {
+  min-height: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.publication-search-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.publication-card[hidden],
+.publication-search-clear[hidden],
+.publication-search-empty[hidden] {
+  display: none !important;
+}
+
 .publication-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/assets/js/publication-search.js
+++ b/assets/js/publication-search.js
@@ -1,0 +1,58 @@
+(() => {
+  const form = document.querySelector('.publication-search');
+  const input = document.querySelector('#publication-search-input');
+  const grid = document.querySelector('#publication-grid');
+  const count = document.querySelector('#publication-result-count');
+  const clear = document.querySelector('.publication-search-clear');
+  const empty = document.querySelector('.publication-search-empty');
+
+  if (!form || !input || !grid || !count || !clear || !empty) return;
+
+  const cards = Array.from(grid.querySelectorAll(':scope > .publication-card'));
+  const normalize = (value) => value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+  const searchable = new Map(cards.map((card) => [card, normalize(card.textContent || '')]));
+
+  const updateUrl = (query) => {
+    const url = new URL(window.location.href);
+    if (query) url.searchParams.set('q', query);
+    else url.searchParams.delete('q');
+    window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+  };
+
+  const filter = () => {
+    const query = input.value.trim();
+    const terms = normalize(query).split(' ').filter(Boolean);
+    let visible = 0;
+
+    cards.forEach((card) => {
+      const matches = terms.every((term) => searchable.get(card).includes(term));
+      card.hidden = !matches;
+      if (matches) visible += 1;
+    });
+
+    count.textContent = `${visible} ${visible === 1 ? 'publication' : 'publications'}`;
+    clear.hidden = !query;
+    empty.hidden = visible !== 0;
+    updateUrl(query);
+  };
+
+  form.addEventListener('submit', (event) => event.preventDefault());
+  input.addEventListener('input', filter);
+  input.addEventListener('search', filter);
+  clear.addEventListener('click', () => {
+    input.value = '';
+    filter();
+    input.focus();
+  });
+
+  const initialQuery = new URL(window.location.href).searchParams.get('q');
+  if (initialQuery) {
+    input.value = initialQuery;
+    filter();
+  }
+})();


### PR DESCRIPTION
## Summary

- add a visible Publications search field without changing CMS data
- filter title, author, journal, year, status, MR number, and other rendered metadata
- support multi-term and accent-insensitive matching
- update an aria-live result count and provide clear/empty states
- preserve the query in the `q` URL parameter for reloads and sharing
- use dependency-free client JavaScript

## Validation

- `bundle exec rake check`
- browser-tested at 1440px and 375px
- `Böckle 2025` returns one matching publication
- zero-result and clear behaviors verified
- URL query persistence verified
- 62 records restored after clearing
- zero horizontal overflow

## Stack

This PR is stacked on #69.

Supersedes #70, which GitHub automatically closed when its head branch was renamed from `agent/…` to `chore/…`.