### PR TITLE
Remove exposed Google Maps API key

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -8,7 +8,7 @@ address:
     description: Located in the Neuenheimer Feld campus area, our research group is
       part of Heidelberg University's prestigious Interdisciplinary Center for
       Scientific Computing (IWR).
-    map_url: https://www.google.com/maps/embed/v1/place?q=Im+Neuenheimer+Feld+205,+69120+Heidelberg,+Germany&key=AIzaSyBFw0Qbyq9zTFTd-tUY6dZWTgaQzuU17R8
+    map_url: https://www.google.com/maps?q=Im+Neuenheimer+Feld+205,+69120+Heidelberg,+Germany&output=embed
 contact_details:
   - phone: +49-6221-54-14715
     phone_hours: "Office hours: Mon-Fri, 9:00-17:00 CET"

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,7 +7,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import yaml
 
@@ -216,12 +216,39 @@ class Validator:
                         f"{location}.target: expected a root-relative path or HTTP(S) URL"
                     )
 
+    def validate_contact(self) -> None:
+        data = self.require_mapping(self.load_yaml("contact.yml"), "_data/contact.yml")
+        if data is None:
+            return
+        addresses = self.require_list(data.get("address"), "_data/contact.yml.address")
+        if addresses is None:
+            return
+        for index, raw_address in enumerate(addresses, start=1):
+            location = f"_data/contact.yml.address[{index}]"
+            address = self.require_mapping(raw_address, location)
+            if address is None:
+                continue
+            map_url = address.get("map_url")
+            self.require_text(map_url, f"{location}.map_url")
+            if not isinstance(map_url, str) or not map_url.strip():
+                continue
+            parsed = urlparse(map_url.strip())
+            if parsed.scheme != "https" or not parsed.netloc:
+                self.error(f"{location}.map_url: expected an HTTPS URL")
+            sensitive_parameters = {"key", "token", "secret"} & {
+                name.casefold() for name in parse_qs(parsed.query)
+            }
+            if sensitive_parameters:
+                names = ", ".join(sorted(sensitive_parameters))
+                self.error(f"{location}.map_url: must not contain secret parameter(s): {names}")
+
     def run(self) -> int:
         self.validate_uploads()
         self.validate_members()
         self.validate_publications()
         self.validate_teaching()
         self.validate_shortlinks()
+        self.validate_contact()
 
         for message in self.warnings:
             print(f"[WARNING] {message}")


### PR DESCRIPTION
## Summary
- replace the public contact-map URL containing a Google API key with the equivalent keyless Google Maps embed URL
- preserve the displayed address and map behavior
- reject future secret-like query parameters in CMS-managed map URLs

## Security context
GitHub secret scanning identified the existing key after repository protections were enabled. This removes it from the current site configuration, but the key remains in Git history and must be revoked or restricted in Google Cloud before the alert can truthfully be resolved.

## Validation
- bundle exec rake check
- generated contact page contains the keyless HTTPS embed URL

AI-assisted implementation; human review is still required before merging.