### PR TITLE
Add accessible site-wide search

### DIFF
--- a/_includes/layout/header.liquid
+++ b/_includes/layout/header.liquid
@@ -14,6 +14,12 @@
             </a>
           </li>
         {% endfor %}
+        <li>
+          <button class="site-search-button" type="button" data-site-search-open aria-haspopup="dialog" aria-controls="site-search-dialog">
+            <i class="fas fa-search" aria-hidden="true"></i>
+            <span>Search</span>
+          </button>
+        </li>
       </ul>
     </nav>
     <button class="nav-toggle" type="button" aria-label="Open navigation" aria-controls="sidebar-navigation" aria-expanded="false">
@@ -33,6 +39,25 @@
         </a>
       </li>
     {% endfor %}
+    <li>
+      <button class="site-search-button" type="button" data-site-search-open aria-haspopup="dialog" aria-controls="site-search-dialog">
+        <i class="fas fa-search" aria-hidden="true"></i>
+        <span>Search</span>
+      </button>
+    </li>
   </ul>
 </div>
 <div class="sidebar-overlay"></div>
+
+<dialog class="site-search-dialog" id="site-search-dialog" aria-labelledby="site-search-title">
+  <div class="site-search-panel">
+    <div class="site-search-heading">
+      <h2 id="site-search-title">Search this site</h2>
+      <button class="site-search-close" type="button" aria-label="Close search">&times;</button>
+    </div>
+    <label class="site-search-label" for="site-search-input">Search pages, people, publications, research, and teaching</label>
+    <input class="site-search-input" id="site-search-input" type="search" inputmode="search" autocomplete="off" placeholder="Enter one or more keywords">
+    <p class="site-search-status" id="site-search-status" role="status" aria-live="polite">Start typing to search the site.</p>
+    <ul class="site-search-results" id="site-search-results"></ul>
+  </div>
+</dialog>

--- a/_includes/scripts/scripts.liquid
+++ b/_includes/scripts/scripts.liquid
@@ -82,3 +82,4 @@
     <script defer src="{{ script | relative_url }}" type="text/javascript"></script>
   {% endfor %}
 {% endif %}
+<script defer src="{{ '/assets/js/site-search.js' | relative_url | bust_file_cache }}"></script>

--- a/_plugins/search_index_generator.rb
+++ b/_plugins/search_index_generator.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'json'
+
+module Jekyll
+  module SiteSearchIndex
+    module_function
+
+    def plain_text(value)
+      flattened = case value
+                  when Array then value.map { |item| plain_text(item) }.join(' ')
+                  when Hash then value.values.map { |item| plain_text(item) }.join(' ')
+                  else value.to_s
+                  end
+      CGI.unescapeHTML(flattened.gsub(%r{<[^>]*>}, ' ').gsub(/\s+/, ' ').strip)
+    end
+
+    def add(entries, title:, url:, type:, text: nil)
+      return if title.to_s.strip.empty? || url.to_s.strip.empty?
+
+      entries << {
+        'title' => plain_text(title),
+        'url' => url,
+        'type' => type,
+        'text' => plain_text(text)
+      }
+    end
+
+    def semester_slug(year, semester)
+      title = if semester == 'Winter'
+                format('Winter Semester %<year>s/%<next_year>02d',
+                       year: year, next_year: (year.to_i + 1) % 100)
+              else
+                "Summer Semester #{year}"
+              end
+      Utils.slugify(title, mode: 'latin')
+    end
+  end
+
+  class SiteSearchPage < PageWithoutAFile
+    def initialize(site, entries)
+      super(site, site.source, '', 'search-index.json')
+      self.content = JSON.generate(entries)
+      self.data = { 'layout' => nil, 'sitemap' => false, 'render_with_liquid' => false }
+    end
+  end
+
+  class SiteSearchGenerator < Generator
+    safe true
+    priority :lowest
+
+    def generate(site)
+      entries = []
+      add_navigation(entries, site)
+      add_members(entries, site)
+      add_publications(entries, site)
+      add_teaching(entries, site)
+      add_research(entries, site)
+      add_links(entries, site)
+      site.pages << SiteSearchPage.new(site, entries)
+    end
+
+    private
+
+    def add_navigation(entries, site)
+      pages_by_url = site.pages.each_with_object({}) { |page, result| result[page.url] = page }
+      Array(site.data['navigation']).each do |item|
+        page = pages_by_url[item['url']]
+        SiteSearchIndex.add(
+          entries,
+          title: item['title'],
+          url: item['url'],
+          type: 'Page',
+          text: page&.data&.fetch('description', nil)
+        )
+      end
+    end
+
+    def add_members(entries, site)
+      Array(site.data.dig('members', 'sections')).each do |section|
+        Array(section['members']).each do |member|
+          slug = Utils.slugify(member['name'], mode: 'latin')[0..100]
+          SiteSearchIndex.add(
+            entries,
+            title: member['name'],
+            url: "/members/#{slug}/",
+            type: 'Member',
+            text: member.reject { |key, _value| %w[photo files].include?(key) }
+          )
+        end
+      end
+    end
+
+    def add_publications(entries, site)
+      Array(site.data.dig('publications', 'publications')).each do |publication|
+        slug = Utils.slugify(publication['title'], mode: 'latin')
+        SiteSearchIndex.add(
+          entries,
+          title: publication['title'],
+          url: "/publications/#{slug}/",
+          type: 'Publication',
+          text: publication.reject { |key, _value| %w[pdfs links].include?(key) }
+        )
+      end
+    end
+
+    def add_teaching(entries, site)
+      Array(site.data.dig('teaching', 'courses')).each do |year_data|
+        year = year_data['year']
+        Array(year_data['semesters']).each do |semester_data|
+          semester = semester_data['semester']
+          semester_slug = SiteSearchIndex.semester_slug(year, semester)
+          Array(semester_data['courses']).each do |course|
+            course_slug = Utils.slugify(course['title'], mode: 'latin')
+            SiteSearchIndex.add(
+              entries,
+              title: course['title'],
+              url: "/teaching/#{year}/#{semester_slug}/#{course_slug}/",
+              type: 'Teaching',
+              text: [year, semester, course.reject { |key, _value| %w[pdfs links].include?(key) }]
+            )
+          end
+        end
+      end
+    end
+
+    def add_research(entries, site)
+      Array(site.data.dig('research', 'research_areas')).each do |area|
+        SiteSearchIndex.add(
+          entries,
+          title: area['title'],
+          url: '/research/',
+          type: 'Research',
+          text: area['content']
+        )
+      end
+    end
+
+    def add_links(entries, site)
+      Array(site.data.dig('links', 'groups')).each do |group|
+        SiteSearchIndex.add(
+          entries,
+          title: group['title'],
+          url: '/links/',
+          type: 'Links',
+          text: group['links']
+        )
+      end
+    end
+  end
+end

--- a/_sass/_site-search.scss
+++ b/_sass/_site-search.scss
@@ -1,0 +1,146 @@
+.site-search-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  border: 0;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  font: inherit;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid white;
+    outline-offset: 2px;
+  }
+}
+
+.site-search-dialog {
+  width: min(720px, calc(100% - 2rem));
+  max-height: min(760px, calc(100dvh - 2rem));
+  padding: 0;
+  border: 0;
+  border-radius: 0.75rem;
+  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 30%);
+
+  &::backdrop {
+    background: rgb(0 0 0 / 55%);
+  }
+}
+
+.site-search-panel {
+  padding: clamp(1rem, 4vw, 2rem);
+  color: var(--global-text-color);
+  background: var(--global-bg-color);
+}
+
+.site-search-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.site-search-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  cursor: pointer;
+}
+
+.site-search-label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+.site-search-input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid #767676;
+  border-radius: 0.4rem;
+  color: inherit;
+  background: inherit;
+  font: inherit;
+  font-size: 1rem;
+}
+
+.site-search-status {
+  min-height: 1.5rem;
+  margin: 0.75rem 0;
+  color: var(--global-text-color-light);
+}
+
+.site-search-results {
+  display: grid;
+  gap: 0.5rem;
+  max-height: min(500px, 55dvh);
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+
+  a {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.2rem 1rem;
+    padding: 0.75rem;
+    border: 1px solid var(--global-divider-color);
+    border-radius: 0.4rem;
+    color: var(--global-text-color);
+    text-decoration: none;
+
+    &:hover,
+    &:focus-visible {
+      border-color: #c61826;
+      background: rgb(198 24 38 / 6%);
+    }
+  }
+}
+
+.site-search-result-title {
+  font-weight: 600;
+}
+
+.site-search-result-type {
+  color: #a1121e;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.site-search-result-excerpt {
+  grid-column: 1 / -1;
+  color: var(--global-text-color-light);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 575.98px) {
+  .site-search-dialog {
+    width: calc(100% - 1rem);
+    max-height: calc(100dvh - 1rem);
+  }
+
+  .site-search-panel {
+    padding: 1rem;
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -24,5 +24,6 @@
 @use "member";
 @use "publications";
 @use "research";
+@use "site-search";
 @use "teaching";
 @use "themes";

--- a/assets/js/site-search.js
+++ b/assets/js/site-search.js
@@ -1,0 +1,98 @@
+(() => {
+  const dialog = document.querySelector('#site-search-dialog');
+  const input = document.querySelector('#site-search-input');
+  const results = document.querySelector('#site-search-results');
+  const status = document.querySelector('#site-search-status');
+  const close = document.querySelector('.site-search-close');
+  const openers = Array.from(document.querySelectorAll('[data-site-search-open]'));
+  if (!dialog || !input || !results || !status || !close || !openers.length) return;
+
+  let documents;
+  let lastOpener;
+  const normalize = (value) => String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const indexUrl = window.prefixBase ? window.prefixBase('/search-index.json') : '/search-index.json';
+  const loadIndex = async () => {
+    if (documents) return documents;
+    const response = await fetch(indexUrl, { credentials: 'same-origin' });
+    if (!response.ok) throw new Error(`Search index returned ${response.status}`);
+    const entries = await response.json();
+    documents = entries.map((entry) => ({
+      ...entry,
+      searchable: normalize(`${entry.title} ${entry.type} ${entry.text}`),
+    }));
+    return documents;
+  };
+
+  const resultLink = (entry) => {
+    const item = document.createElement('li');
+    const link = document.createElement('a');
+    const heading = document.createElement('span');
+    const type = document.createElement('span');
+    const excerpt = document.createElement('span');
+
+    link.href = window.prefixBase ? window.prefixBase(entry.url) : entry.url;
+    heading.className = 'site-search-result-title';
+    heading.textContent = entry.title;
+    type.className = 'site-search-result-type';
+    type.textContent = entry.type;
+    excerpt.className = 'site-search-result-excerpt';
+    excerpt.textContent = entry.text.length > 180 ? `${entry.text.slice(0, 177)}…` : entry.text;
+    link.append(heading, type, excerpt);
+    item.append(link);
+    return item;
+  };
+
+  const search = async () => {
+    const query = input.value.trim();
+    results.replaceChildren();
+    if (!query) {
+      status.textContent = 'Start typing to search the site.';
+      return;
+    }
+
+    const terms = normalize(query).split(' ').filter(Boolean);
+    try {
+      const entries = await loadIndex();
+      const matches = entries
+        .filter((entry) => terms.every((term) => entry.searchable.includes(term)))
+        .slice(0, 12);
+      matches.forEach((entry) => results.append(resultLink(entry)));
+      status.textContent = matches.length
+        ? `${matches.length} ${matches.length === 1 ? 'result' : 'results'}`
+        : 'No results found.';
+    } catch (_error) {
+      status.textContent = 'Search is temporarily unavailable. Please try again.';
+    }
+  };
+
+  const openSearch = (opener) => {
+    lastOpener = opener;
+    if (typeof dialog.showModal === 'function') dialog.showModal();
+    else dialog.setAttribute('open', '');
+    input.focus();
+    loadIndex().catch(() => {});
+  };
+
+  openers.forEach((opener) => opener.addEventListener('click', () => openSearch(opener)));
+  close.addEventListener('click', () => dialog.close());
+  input.addEventListener('input', search);
+  input.addEventListener('search', search);
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+  dialog.addEventListener('close', () => lastOpener?.focus());
+  document.addEventListener('keydown', (event) => {
+    const target = event.target;
+    const isTyping = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target?.isContentEditable;
+    if ((event.key === '/' && !isTyping) || (event.key.toLocaleLowerCase() === 'k' && (event.ctrlKey || event.metaKey))) {
+      event.preventDefault();
+      openSearch(openers[0]);
+    }
+  });
+})();

--- a/scripts/check_generated_site.py
+++ b/scripts/check_generated_site.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -47,6 +48,27 @@ def main() -> int:
             for element in soup.find_all(tag):
                 if element.has_attr(attribute) and not str(element[attribute]).strip():
                     errors.append(f"{relative}: empty {tag}[{attribute}]")
+
+    search_index_path = SITE_DIR / "search-index.json"
+    try:
+        search_entries = json.loads(search_index_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        errors.append(f"_site/search-index.json: cannot be read: {error}")
+        search_entries = []
+    if not isinstance(search_entries, list) or not search_entries:
+        errors.append("_site/search-index.json: expected a non-empty list")
+    else:
+        for index, entry in enumerate(search_entries, start=1):
+            location = f"_site/search-index.json[{index}]"
+            if not isinstance(entry, dict):
+                errors.append(f"{location}: expected an object")
+                continue
+            for field in ("title", "url", "type", "text"):
+                if not isinstance(entry.get(field), str):
+                    errors.append(f"{location}.{field}: expected text")
+            url = entry.get("url")
+            if isinstance(url, str) and (not url.startswith("/") or url.startswith("//")):
+                errors.append(f"{location}.url: expected a root-relative URL")
 
     for error in errors:
         print(f"[ERROR] {error}")


### PR DESCRIPTION
## Summary
- add a keyboard-accessible site search dialog to desktop and mobile navigation
- generate a private-by-design local JSON index from public pages and CMS data at build time
- search pages, members, publications, teaching, research, and links with accent-insensitive multi-term matching
- load the 142 KiB index only when search is opened, with no third-party search service or tracking
- validate the generated index as part of repository checks

## Accessibility and behavior
- native modal dialog, focus restoration, Escape support, visible labels, live result count
- Ctrl/Cmd+K and slash keyboard shortcuts
- 44px controls and 16px mobile input text
- safe DOM construction using textContent rather than HTML injection

## Validation
- bundle exec rake check
- generated index: 233 entries across six content types
- desktop and 390px mobile browser interaction tests
- query `Böckle 2015`: correct publication and teaching results
- no console/page errors or horizontal overflow at 1200, 1280, 1366, 1440, and 390px

AI-assisted implementation; human review is still required before merging.