### PR TITLE
Address Copilot findings and refine search experience

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,8 +33,9 @@ task :build do
   sh "bundle exec jekyll build"
 end
 
-desc "Run unit tests for custom Jekyll plugins"
+desc "Run unit tests for custom validators and Jekyll plugins"
 task :test do
+  sh "#{python} scripts/test_validate.py"
   sh "bundle exec ruby scripts/test_plugins.rb"
 end
 

--- a/_includes/layout/header.liquid
+++ b/_includes/layout/header.liquid
@@ -52,12 +52,30 @@
 <dialog class="site-search-dialog" id="site-search-dialog" aria-labelledby="site-search-title">
   <div class="site-search-panel">
     <div class="site-search-heading">
-      <h2 id="site-search-title">Search this site</h2>
-      <button class="site-search-close" type="button" aria-label="Close search">&times;</button>
+      <div class="site-search-heading-icon" aria-hidden="true">
+        <i class="fas fa-search"></i>
+      </div>
+      <div class="site-search-heading-copy">
+        <span class="site-search-eyebrow">Explore the research group</span>
+        <h2 id="site-search-title">Search this site</h2>
+        <p>Find people, publications, research areas, and teaching materials.</p>
+      </div>
+      <button class="site-search-close" type="button" aria-label="Close search">
+        <i class="fas fa-times" aria-hidden="true"></i>
+      </button>
     </div>
-    <label class="site-search-label" for="site-search-input">Search pages, people, publications, research, and teaching</label>
-    <input class="site-search-input" id="site-search-input" type="search" inputmode="search" autocomplete="off" placeholder="Enter one or more keywords">
-    <p class="site-search-status" id="site-search-status" role="status" aria-live="polite">Start typing to search the site.</p>
-    <ul class="site-search-results" id="site-search-results"></ul>
+    <div class="site-search-body">
+      <label class="visually-hidden" for="site-search-input">Search pages, people, publications, research, and teaching</label>
+      <div class="site-search-control">
+        <i class="fas fa-search" aria-hidden="true"></i>
+        <input class="site-search-input" id="site-search-input" type="search" inputmode="search" autocomplete="off" placeholder="What are you looking for?">
+        <kbd aria-hidden="true">/</kbd>
+      </div>
+      <div class="site-search-meta">
+        <p class="site-search-status" id="site-search-status" role="status" aria-live="polite">Start typing to search the site.</p>
+        <span class="site-search-hint">Esc to close</span>
+      </div>
+      <ul class="site-search-results" id="site-search-results"></ul>
+    </div>
   </div>
 </dialog>

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -106,18 +106,20 @@ layout: default
             <h2 class="h3 fw-bold mb-4 text-dark border-bottom pb-2">Software Packages</h2>
             <div class="list-group list-group-flush">
               {% for software in matching_software %}
+              {% assign safe_software_link = software.link | sanitize_url %}
+              {% assign safe_thesis_link = software.thesis | sanitize_url %}
               <div class="list-group-item px-0 py-4 publication-item">
                 <h5 class="h5 fw-bold mb-2">
-                  {% if software.link %}
-                  <a href="{{ software.link }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">{{ software.title
+                  {% if software.link and safe_software_link != "#" %}
+                  <a href="{{ safe_software_link | escape }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">{{ software.title
                     }}</a>
                   {% else %}
                   {{ software.title }}
                   {% endif %}
                 </h5>
                 <div class="text-secondary mb-2">{{ software.description | markdownify }}</div>
-                {% if software.thesis %}
-                <a href="{{ software.thesis }}" class="btn-custom btn-custom-danger" target="_blank" rel="noopener noreferrer">
+                {% if software.thesis and safe_thesis_link != "#" %}
+                <a href="{{ safe_thesis_link | escape }}" class="btn-custom btn-custom-danger" target="_blank" rel="noopener noreferrer">
                   <i class="fas fa-file-pdf me-1"></i> Thesis
                 </a>
                 {% endif %}

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -14,25 +14,38 @@ scripts:
 ---
 
 <div class="publications-container">
-  <form class="publication-search" role="search" aria-label="Search publications" novalidate>
-    <label for="publication-search-input">Search publications</label>
-    <div class="publication-search-control">
-      <i class="fas fa-search" aria-hidden="true"></i>
-      <input
-        id="publication-search-input"
-        type="search"
-        inputmode="search"
-        autocomplete="off"
-        placeholder="Title, author, journal, year, status, or MR number"
-        aria-controls="publication-grid"
-        aria-describedby="publication-result-count"
-      >
-      <button type="button" class="publication-search-clear" aria-label="Clear publication search" hidden>Clear</button>
+  <section class="publication-search-panel" aria-labelledby="publications-heading">
+    <div class="publication-search-heading">
+      <div class="publication-search-heading-icon" aria-hidden="true">
+        <i class="fas fa-book-open"></i>
+      </div>
+      <div>
+        <span class="publication-search-eyebrow">Research output</span>
+        <h1 id="publications-heading">Publications</h1>
+        <p>Browse articles, preprints, books, and software from the research group.</p>
+      </div>
     </div>
-  </form>
-  <div class="search-results-header" aria-live="polite" aria-atomic="true">
-    <span class="results-count" id="publication-result-count">{{ site.data.publications.publications.size }} publications</span>
-  </div>
+    <form class="publication-search" role="search" aria-label="Search publications" novalidate>
+      <label for="publication-search-input">Search the publication archive</label>
+      <div class="publication-search-control">
+        <i class="fas fa-search" aria-hidden="true"></i>
+        <input
+          id="publication-search-input"
+          type="search"
+          inputmode="search"
+          autocomplete="off"
+          placeholder="Title, author, journal, year, status, or MR number"
+          aria-controls="publication-grid"
+          aria-describedby="publication-result-count"
+        >
+        <button type="button" class="publication-search-clear" aria-label="Clear publication search" hidden>Clear</button>
+      </div>
+    </form>
+    <div class="search-results-header" aria-live="polite" aria-atomic="true">
+      <i class="fas fa-list" aria-hidden="true"></i>
+      <span class="results-count" id="publication-result-count">{{ site.data.publications.publications.size }} publications</span>
+    </div>
+  </section>
   <div class="publication-grid" id="publication-grid">
     {% assign all_pubs = site.data.publications.publications %}
     {% assign pubs_with_year = all_pubs | where_exp: "item", "item.year != nil and item.year != ''" %}
@@ -121,10 +134,16 @@ scripts:
     <h2>Software Packages</h2>
     <div class="publication-grid">
       {% for software in site.data.publications.software %}
+        {% assign safe_software_link = software.link | sanitize_url %}
+        {% assign safe_thesis_link = software.thesis | sanitize_url %}
         <div class="publication-card">
           <div class="publication-main">
             <div class="publication-title">
-              <a href="{{ software.link | escape }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">{{ software.title | escape }}</a>
+              {% if software.link and safe_software_link != "#" %}
+                <a href="{{ safe_software_link | escape }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none text-dark">{{ software.title | escape }}</a>
+              {% else %}
+                {{ software.title | escape }}
+              {% endif %}
             </div>
             <div class="publication-details">
               {{ software.description | markdownify }}
@@ -132,16 +151,18 @@ scripts:
             <div class="publication-authors">
               By {{ software.author | escape }}
             </div>
-            {% if software.thesis %}
+            {% if software.thesis and safe_thesis_link != "#" %}
             <div class="publication-links mt-2">
-               <a href="{{ software.thesis | escape }}" target="_blank" rel="noopener noreferrer">Thesis</a>
+               <a href="{{ safe_thesis_link | escape }}" target="_blank" rel="noopener noreferrer">Thesis</a>
             </div>
             {% endif %}
           </div>
           <div class="publication-sidebar">
-             <a href="{{ software.link | escape }}" target="_blank" rel="noopener noreferrer" class="btn-custom btn-custom-outline btn-custom-sm">
+             {% if software.link and safe_software_link != "#" %}
+             <a href="{{ safe_software_link | escape }}" target="_blank" rel="noopener noreferrer" class="btn-custom btn-custom-outline btn-custom-sm">
                 <i class="fas fa-code"></i> {{ software.link_text | escape }}
              </a>
+             {% endif %}
           </div>
         </div>
       {% endfor %}

--- a/_plugins/search_index_generator.rb
+++ b/_plugins/search_index_generator.rb
@@ -86,7 +86,7 @@ module Jekyll
             title: member['name'],
             url: "/members/#{slug}/",
             type: 'Member',
-            text: member.reject { |key, _value| %w[photo files].include?(key) }
+            text: [member['role'], member['research_interests'], member['body']]
           )
         end
       end
@@ -97,10 +97,10 @@ module Jekyll
         slug = Utils.slugify(publication['title'], mode: 'latin')
         SiteSearchIndex.add(
           entries,
-          title: publication['title'],
-          url: "/publications/#{slug}/",
-          type: 'Publication',
-          text: publication.reject { |key, _value| %w[pdfs links].include?(key) }
+            title: publication['title'],
+            url: "/publications/#{slug}/",
+            type: 'Publication',
+            text: [publication['authors'], publication['journal_details'], publication['year'], publication['status']]
         )
       end
     end
@@ -118,7 +118,7 @@ module Jekyll
               title: course['title'],
               url: "/teaching/#{year}/#{semester_slug}/#{course_slug}/",
               type: 'Teaching',
-              text: [year, semester, course.reject { |key, _value| %w[pdfs links].include?(key) }]
+              text: [course['instructor'], year, semester, course['description']]
             )
           end
         end
@@ -139,12 +139,15 @@ module Jekyll
 
     def add_links(entries, site)
       Array(site.data.dig('links', 'groups')).each do |group|
+        link_summaries = Array(group['links']).map do |link|
+          [link['title'], link['description']]
+        end
         SiteSearchIndex.add(
           entries,
           title: group['title'],
           url: '/links/',
           type: 'Links',
-          text: group['links']
+          text: link_summaries
         )
       end
     end

--- a/_sass/_publications.scss
+++ b/_sass/_publications.scss
@@ -1,11 +1,59 @@
 @use 'variables' as v;
 
+.publication-search-panel {
+  margin-bottom: 1.25rem;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  border: 1px solid var(--border-color);
+  border-top: 4px solid v.$primary;
+  border-radius: v.$radius-md;
+  background: linear-gradient(135deg, v.$red-50 0%, var(--bg-primary) 58%);
+  box-shadow: v.$shadow-sm;
+}
+
+.publication-search-heading {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.2rem;
+
+  h1 {
+    margin: 0.05rem 0 0;
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+  }
+}
+
+.publication-search-heading-icon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 3.25rem;
+  height: 3.25rem;
+  place-items: center;
+  border: 1px solid v.$red-200;
+  border-radius: 50%;
+  background: v.$red-100;
+  color: v.$red-800;
+  font-size: 1.25rem;
+}
+
+.publication-search-eyebrow {
+  color: v.$red-800;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
 .publication-search {
-  margin-bottom: 0.5rem;
+  margin: 0;
 
   label {
     display: block;
-    margin-bottom: 0.35rem;
+    margin-bottom: 0.45rem;
     font-weight: 600;
   }
 }
@@ -24,16 +72,19 @@
 
   input {
     width: 100%;
-    min-height: 44px;
+    min-height: 52px;
     padding: 0.65rem 4.75rem 0.65rem 2.5rem;
     color: var(--text-primary);
     background: var(--bg-primary);
-    border: 1px solid var(--border-color);
+    border: 1px solid v.$gray-300;
     border-radius: v.$radius-sm;
+    box-shadow: v.$shadow-sm;
+    transition: border-color 160ms ease, box-shadow 160ms ease;
 
-    &:focus-visible {
-      outline: 2px solid var(--primary);
-      outline-offset: 2px;
+    &:focus {
+      border-color: v.$primary;
+      outline: 0;
+      box-shadow: 0 0 0 3px rgb(198 24 38 / 14%);
     }
   }
 }
@@ -58,8 +109,22 @@
 }
 
 .search-results-header {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
   min-height: 1.5rem;
-  margin-bottom: 0.5rem;
+  margin-top: 0.85rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: v.$radius-full;
+  background: v.$red-100;
+  color: v.$red-800;
+  font-size: 0.85rem;
+  font-weight: 700;
+
+  i,
+  span {
+    color: inherit;
+  }
 }
 
 .publication-search-empty {
@@ -78,6 +143,21 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 0.5rem;
+}
+
+@media (max-width: 575.98px) {
+  .publication-search-panel {
+    border-radius: v.$radius-sm;
+  }
+
+  .publication-search-heading {
+    align-items: flex-start;
+  }
+
+  .publication-search-heading-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 }
 
 .publication-card {

--- a/_sass/_site-search.scss
+++ b/_sass/_site-search.scss
@@ -1,3 +1,5 @@
+@use 'variables' as v;
+
 .site-search-button {
   display: inline-flex;
   align-items: center;
@@ -22,125 +24,334 @@
 }
 
 .site-search-dialog {
-  width: min(720px, calc(100% - 2rem));
-  max-height: min(760px, calc(100dvh - 2rem));
+  width: min(780px, calc(100% - 2rem));
+  max-height: min(800px, calc(100dvh - 2rem));
   padding: 0;
-  border: 0;
-  border-radius: 0.75rem;
-  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 30%);
+  overflow: hidden;
+  border: 1px solid v.$red-800;
+  border-radius: v.$radius-md;
+  background: var(--bg-primary);
+  box-shadow: 0 1.75rem 5rem rgb(0 0 0 / 38%);
 
   &::backdrop {
-    background: rgb(0 0 0 / 55%);
+    background: rgb(17 24 39 / 68%);
+    backdrop-filter: blur(3px);
   }
 }
 
 .site-search-panel {
-  padding: clamp(1rem, 4vw, 2rem);
-  color: var(--global-text-color);
-  background: var(--global-bg-color);
+  color: var(--text-primary);
+  background: var(--bg-primary);
 }
 
 .site-search-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   gap: 1rem;
-  margin-bottom: 1rem;
+  align-items: center;
+  padding: 1.4rem 1.5rem;
+  background: linear-gradient(135deg, v.$red-900 0%, v.$primary 72%, v.$red-600 100%);
+
+  h2,
+  p,
+  span,
+  i {
+    color: white;
+  }
 
   h2 {
-    margin: 0;
+    margin: 0.1rem 0 0;
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    line-height: 1.15;
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    opacity: 0.88;
+    font-size: 0.95rem;
   }
 }
 
+.site-search-heading-icon {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 35%);
+  border-radius: 50%;
+  background: rgb(255 255 255 / 12%);
+  font-size: 1.15rem;
+}
+
+.site-search-eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
 .site-search-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: grid;
   width: 44px;
   height: 44px;
   padding: 0;
-  border: 0;
+  place-items: center;
+  border: 1px solid rgb(255 255 255 / 32%);
   border-radius: 50%;
-  background: transparent;
-  color: inherit;
-  font-size: 1.75rem;
+  background: rgb(255 255 255 / 10%);
+  color: white;
   cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(255 255 255 / 22%);
+    transform: rotate(4deg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid white;
+    outline-offset: 2px;
+  }
 }
 
-.site-search-label {
-  display: block;
-  margin-bottom: 0.4rem;
-  font-weight: 600;
+.site-search-body {
+  padding: 1.25rem 1.5rem 1.5rem;
+}
+
+.site-search-control {
+  position: relative;
+
+  > i {
+    position: absolute;
+    top: 50%;
+    left: 1rem;
+    color: v.$red-700;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
+
+  kbd {
+    position: absolute;
+    top: 50%;
+    right: 0.85rem;
+    min-width: 1.8rem;
+    padding: 0.12rem 0.4rem;
+    border: 1px solid var(--border-color);
+    border-bottom-width: 2px;
+    border-radius: 0.35rem;
+    background: var(--bg-secondary);
+    color: var(--text-muted);
+    font: inherit;
+    font-size: 0.78rem;
+    text-align: center;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
 }
 
 .site-search-input {
   width: 100%;
-  min-height: 48px;
-  padding: 0.65rem 0.85rem;
-  border: 1px solid #767676;
-  border-radius: 0.4rem;
-  color: inherit;
-  background: inherit;
+  min-height: 54px;
+  padding: 0.75rem 3.2rem 0.75rem 2.8rem;
+  border: 1px solid v.$gray-300;
+  border-radius: v.$radius-sm;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: v.$shadow-sm;
   font: inherit;
-  font-size: 1rem;
+  font-size: 1.05rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+
+  &:focus {
+    border-color: v.$red-700;
+    outline: 0;
+    box-shadow: 0 0 0 3px rgb(198 24 38 / 14%);
+  }
+}
+
+.site-search-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  min-height: 2.8rem;
 }
 
 .site-search-status {
-  min-height: 1.5rem;
-  margin: 0.75rem 0;
-  color: var(--global-text-color-light);
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.site-search-hint {
+  color: var(--text-muted);
+  font-size: 0.8rem;
 }
 
 .site-search-results {
   display: grid;
-  gap: 0.5rem;
-  max-height: min(500px, 55dvh);
+  gap: 0.6rem;
+  max-height: min(480px, 52dvh);
   margin: 0;
-  padding: 0;
+  padding: 0 0.2rem 0 0;
   overflow-y: auto;
   list-style: none;
+  scrollbar-color: v.$gray-400 transparent;
 
   a {
     display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.2rem 1rem;
-    padding: 0.75rem;
-    border: 1px solid var(--global-divider-color);
-    border-radius: 0.4rem;
-    color: var(--global-text-color);
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.85rem;
+    align-items: start;
+    padding: 0.9rem 1rem;
+    border: 1px solid var(--border-color);
+    border-left: 4px solid transparent;
+    border-radius: v.$radius-sm;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
     text-decoration: none;
+    box-shadow: v.$shadow-sm;
+    transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 
     &:hover,
     &:focus-visible {
-      border-color: #c61826;
-      background: rgb(198 24 38 / 6%);
+      border-color: v.$red-300;
+      border-left-color: v.$red-700;
+      background: v.$red-50;
+      box-shadow: v.$shadow-md;
+      text-decoration: none;
+      transform: translateX(2px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid v.$red-700;
+      outline-offset: 2px;
     }
   }
 }
 
+.site-search-result-icon {
+  display: grid;
+  width: 2.4rem;
+  height: 2.4rem;
+  place-items: center;
+  border-radius: 50%;
+  background: v.$red-100;
+  color: v.$red-800;
+}
+
+.site-search-result-content {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.site-search-result-heading {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .site-search-result-title {
-  font-weight: 600;
+  overflow: hidden;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .site-search-result-type {
-  color: #a1121e;
-  font-size: 0.85rem;
-  font-weight: 600;
+  flex: 0 0 auto;
+  padding: 0.18rem 0.55rem;
+  border-radius: v.$radius-full;
+  background: v.$red-100;
+  color: v.$red-800;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .site-search-result-excerpt {
-  grid-column: 1 / -1;
-  color: var(--global-text-color-light);
-  font-size: 0.9rem;
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.site-search-empty {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  padding: 2.5rem 1rem;
+  border: 1px dashed v.$gray-300;
+  border-radius: v.$radius-sm;
+  color: var(--text-muted);
+  text-align: center;
+
+  i {
+    margin-bottom: 0.35rem;
+    color: v.$red-700;
+    font-size: 1.5rem;
+  }
 }
 
 @media (max-width: 575.98px) {
   .site-search-dialog {
-    width: calc(100% - 1rem);
-    max-height: calc(100dvh - 1rem);
+    width: 100%;
+    max-width: none;
+    height: 100dvh;
+    max-height: 100dvh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
   }
 
-  .site-search-panel {
+  .site-search-heading {
+    grid-template-columns: 1fr auto;
     padding: 1rem;
+
+    p {
+      display: none;
+    }
+  }
+
+  .site-search-heading-icon {
+    display: none;
+  }
+
+  .site-search-body {
+    padding: 1rem;
+  }
+
+  .site-search-hint,
+  .site-search-control kbd {
+    display: none;
+  }
+
+  .site-search-input {
+    padding-right: 1rem;
+  }
+
+  .site-search-results {
+    max-height: calc(100dvh - 235px);
+  }
+
+  .site-search-results a {
+    gap: 0.7rem;
+    padding: 0.8rem;
+  }
+
+  .site-search-result-heading {
+    align-items: flex-start;
+  }
+
+  .site-search-result-title {
+    white-space: normal;
   }
 }

--- a/_teaching/index.md
+++ b/_teaching/index.md
@@ -94,8 +94,9 @@ description: "An overview of our courses, seminars, and lectures, organized by s
                 {% if course.links or course.pdfs %}
                 <div class="course-resources mt-2 position-relative" style="z-index: 2;">
                   {% for link in course.links %}
-                    {% if link.url and link.url != empty %}
-                    <a href="{{ link.url | escape }}" class="btn btn-sm btn-outline-primary me-1 mb-1" target="_blank" rel="noopener">
+                    {% assign safe_link_url = link.url | sanitize_url %}
+                    {% if link.url and link.url != empty and safe_link_url != "#" %}
+                    <a href="{{ safe_link_url | escape }}" class="btn btn-sm btn-outline-primary me-1 mb-1" target="_blank" rel="noopener">
                       <i class="fas fa-external-link-alt"></i> {{ link.label | default: "More Info" | escape }}
                     </a>
                     {% else %}

--- a/assets/js/site-search.js
+++ b/assets/js/site-search.js
@@ -9,6 +9,14 @@
 
   let documents;
   let lastOpener;
+  const typeIcons = {
+    Page: 'fa-compass',
+    Member: 'fa-user',
+    Publication: 'fa-book-open',
+    Teaching: 'fa-chalkboard-teacher',
+    Research: 'fa-flask',
+    Links: 'fa-link',
+  };
   const normalize = (value) => String(value || '')
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '')
@@ -32,20 +40,41 @@
   const resultLink = (entry) => {
     const item = document.createElement('li');
     const link = document.createElement('a');
+    const icon = document.createElement('span');
+    const content = document.createElement('span');
+    const headingRow = document.createElement('span');
     const heading = document.createElement('span');
     const type = document.createElement('span');
     const excerpt = document.createElement('span');
 
+    item.className = 'site-search-result';
     link.href = window.prefixBase ? window.prefixBase(entry.url) : entry.url;
+    icon.className = 'site-search-result-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    const iconGlyph = document.createElement('i');
+    iconGlyph.className = `fas ${typeIcons[entry.type] || 'fa-file'}`;
+    icon.append(iconGlyph);
+    content.className = 'site-search-result-content';
+    headingRow.className = 'site-search-result-heading';
     heading.className = 'site-search-result-title';
     heading.textContent = entry.title;
     type.className = 'site-search-result-type';
     type.textContent = entry.type;
     excerpt.className = 'site-search-result-excerpt';
-    excerpt.textContent = entry.text.length > 180 ? `${entry.text.slice(0, 177)}…` : entry.text;
-    link.append(heading, type, excerpt);
+    excerpt.textContent = entry.text.length > 150 ? `${entry.text.slice(0, 147)}…` : entry.text;
+    headingRow.append(heading, type);
+    content.append(headingRow);
+    if (entry.text) content.append(excerpt);
+    link.append(icon, content);
     item.append(link);
     return item;
+  };
+
+  const renderEmptyState = () => {
+    const item = document.createElement('li');
+    item.className = 'site-search-empty';
+    item.innerHTML = '<i class="fas fa-search" aria-hidden="true"></i><strong>No matching pages</strong><span>Try a person, topic, publication title, or course.</span>';
+    results.append(item);
   };
 
   const search = async () => {
@@ -63,6 +92,7 @@
         .filter((entry) => terms.every((term) => entry.searchable.includes(term)))
         .slice(0, 12);
       matches.forEach((entry) => results.append(resultLink(entry)));
+      if (!matches.length) renderEmptyState();
       status.textContent = matches.length
         ? `${matches.length} ${matches.length === 1 ? 'result' : 'results'}`
         : 'No results found.';
@@ -72,7 +102,16 @@
   };
 
   const openSearch = (opener) => {
-    lastOpener = opener;
+    const sidebar = opener.closest('.sidebar-nav');
+    const navToggle = document.querySelector('.nav-toggle');
+    if (sidebar) {
+      sidebar.classList.remove('is-open');
+      sidebar.setAttribute('aria-hidden', 'true');
+      document.querySelector('.sidebar-overlay')?.classList.remove('is-active');
+      navToggle?.setAttribute('aria-expanded', 'false');
+      navToggle?.setAttribute('aria-label', 'Open navigation');
+    }
+    lastOpener = sidebar && navToggle ? navToggle : opener;
     if (typeof dialog.showModal === 'function') dialog.showModal();
     else dialog.setAttribute('open', '');
     input.focus();
@@ -90,6 +129,11 @@
   document.addEventListener('keydown', (event) => {
     const target = event.target;
     const isTyping = target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target?.isContentEditable;
+    if (event.key === 'Escape' && dialog.open) {
+      event.preventDefault();
+      dialog.close();
+      return;
+    }
     if ((event.key === '/' && !isTyping) || (event.key.toLocaleLowerCase() === 'k' && (event.ctrlKey || event.metaKey))) {
       event.preventDefault();
       openSearch(openers[0]);

--- a/e2e/site-smoke.spec.js
+++ b/e2e/site-smoke.spec.js
@@ -53,6 +53,43 @@ test('CMS-backed overview pages contain generated entries', async ({ page }) => 
   expect(await page.locator('.course-card').count()).toBeGreaterThan(0);
 });
 
+test('site search returns readable results and an empty state', async ({ page }) => {
+  await page.goto('./');
+  await page.keyboard.press('/');
+
+  const dialog = page.locator('#site-search-dialog');
+  const input = page.locator('#site-search-input');
+  await expect(dialog).toBeVisible();
+  await expect(input).toBeFocused();
+
+  await input.fill('arithmetic');
+  await expect(page.locator('#site-search-results > li').first()).toBeVisible();
+  await expect(page.locator('.site-search-result-type').first()).not.toBeEmpty();
+
+  await input.fill('definitely-no-result-xyz');
+  await expect(page.locator('.site-search-empty')).toBeVisible();
+  await expect(page.locator('#site-search-status')).toHaveText('No results found.');
+
+  await page.keyboard.press('Escape');
+  await expect(dialog).not.toBeVisible();
+});
+
+test('publication search filters and clears without changing source content', async ({ page }) => {
+  await page.goto('publications/');
+  const cards = page.locator('#publication-grid > .publication-card');
+  const total = await cards.count();
+
+  await page.locator('#publication-search-input').fill('arithmetic');
+  const filtered = await page.locator('#publication-grid > .publication-card:visible').count();
+  expect(filtered).toBeGreaterThan(0);
+  expect(filtered).toBeLessThan(total);
+  await expect(page).toHaveURL(/\?q=arithmetic$/);
+
+  await page.locator('.publication-search-clear').click();
+  expect(await page.locator('#publication-grid > .publication-card:visible').count()).toBe(total);
+  await expect(page).not.toHaveURL(/\?q=/);
+});
+
 test.describe('mobile navigation', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
@@ -70,6 +107,20 @@ test.describe('mobile navigation', () => {
     await page.keyboard.press('Escape');
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
     await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('hands off cleanly from navigation to site search', async ({ page }) => {
+    await page.goto('./');
+
+    const toggle = page.locator('.nav-toggle');
+    const sidebar = page.locator('#sidebar-navigation');
+    await toggle.click();
+    await page.locator('#sidebar-navigation [data-site-search-open]').click();
+
+    await expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('#site-search-dialog')).toBeVisible();
+    await expect(page.locator('#site-search-input')).toBeFocused();
   });
 });
 

--- a/scripts/test_validate.py
+++ b/scripts/test_validate.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Unit tests for repository validation helpers."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import PurePosixPath
+
+from validate import (
+    has_safe_path_components,
+    is_sensitive_query_parameter,
+    resolve_repo_file,
+)
+
+
+class ValidationHelpersTest(unittest.TestCase):
+    def test_upload_paths_require_safe_components(self) -> None:
+        self.assertTrue(has_safe_path_components(PurePosixPath("course/notes-01.pdf")))
+        self.assertFalse(has_safe_path_components(PurePosixPath("bad dir/notes.pdf")))
+        self.assertFalse(has_safe_path_components(PurePosixPath("course/notes (final).pdf")))
+
+    def test_repo_paths_reject_absolute_and_traversing_values(self) -> None:
+        self.assertIsNotNone(resolve_repo_file(".pages.yml"))
+        self.assertIsNone(resolve_repo_file("/etc/passwd"))
+        self.assertIsNone(resolve_repo_file("../outside.yml"))
+        self.assertIsNone(resolve_repo_file("_data\\contact.yml"))
+
+    def test_secret_parameter_variants_are_detected(self) -> None:
+        for name in (
+            "key",
+            "api_key",
+            "apikey",
+            "maps-key",
+            "access_token",
+            "client_secret",
+            "private.token",
+        ):
+            with self.subTest(name=name):
+                self.assertTrue(is_sensitive_query_parameter(name))
+
+        for name in ("query", "language", "marker", "tokenize"):
+            with self.subTest(name=name):
+                self.assertFalse(is_sensitive_query_parameter(name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qsl, urlparse
 
 import yaml
 
@@ -16,8 +16,44 @@ ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = ROOT / "_data"
 UPLOADS_DIR = ROOT / "assets" / "uploads"
 SAFE_FILENAME = re.compile(r"^[A-Za-z0-9._-]+$")
+SENSITIVE_QUERY_PARAMETER = re.compile(
+    r"(?:^|[._-])(?:api[._-]?key|access[._-]?token|key|token|secret)(?:$|[._-])",
+    re.IGNORECASE,
+)
 UPLOAD_EXTENSIONS = {".gif", ".jpeg", ".jpg", ".pdf", ".png", ".svg", ".webp"}
 LEGACY_UPLOAD_MISMATCHES = {"assets/uploads/Boeckle.pdf"}
+
+
+def has_safe_path_components(path: PurePosixPath) -> bool:
+    return bool(path.parts) and all(SAFE_FILENAME.fullmatch(part) for part in path.parts)
+
+
+def resolve_repo_file(value: str) -> Path | None:
+    if not value or "\\" in value:
+        return None
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    root = ROOT.resolve()
+    candidate = (root / Path(*path.parts)).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def is_sensitive_query_parameter(name: str) -> bool:
+    normalized = name.casefold()
+    compact = re.sub(r"[._-]", "", normalized)
+    return compact in {
+        "key",
+        "apikey",
+        "token",
+        "accesstoken",
+        "secret",
+        "clientsecret",
+    } or bool(SENSITIVE_QUERY_PARAMETER.search(normalized))
 
 
 class Validator:
@@ -68,8 +104,9 @@ class Validator:
                 continue
             relative = path.relative_to(ROOT)
             relative_name = relative.as_posix()
-            if not SAFE_FILENAME.fullmatch(path.name):
-                self.error(f"{relative}: filename contains unsafe characters")
+            upload_path = path.relative_to(UPLOADS_DIR)
+            if not has_safe_path_components(PurePosixPath(upload_path.as_posix())):
+                self.error(f"{relative}: path contains unsafe characters")
             if path.suffix.casefold() not in UPLOAD_EXTENSIONS:
                 self.error(f"{relative}: unsupported upload type {path.suffix or '(none)'}")
             try:
@@ -86,7 +123,8 @@ class Validator:
 
             if path.suffix.casefold() == ".pdf":
                 try:
-                    is_pdf = path.read_bytes()[:5] == b"%PDF-"
+                    with path.open("rb") as stream:
+                        is_pdf = stream.read(5) == b"%PDF-"
                 except OSError as error:
                     self.warning(f"{relative}: cannot inspect file type: {error}")
                     continue
@@ -127,8 +165,12 @@ class Validator:
                     names.add(name)
                 path = item.get("path")
                 self.require_text(path, f"{location}.path")
-                if isinstance(path, str) and not (ROOT / path).is_file():
-                    self.error(f"{location}.path: file does not exist: {path}")
+                if isinstance(path, str):
+                    repo_file = resolve_repo_file(path)
+                    if repo_file is None:
+                        self.error(f"{location}.path: expected a safe repository-relative path")
+                    elif not repo_file.is_file():
+                        self.error(f"{location}.path: file does not exist: {path}")
                 if item.get("type") == "file":
                     operations = self.require_mapping(
                         item.get("operations"), f"{location}.operations"
@@ -323,8 +365,10 @@ class Validator:
             parsed = urlparse(map_url.strip())
             if parsed.scheme != "https" or not parsed.netloc:
                 self.error(f"{location}.map_url: expected an HTTPS URL")
-            sensitive_parameters = {"key", "token", "secret"} & {
-                name.casefold() for name in parse_qs(parsed.query)
+            sensitive_parameters = {
+                name
+                for name, _value in parse_qsl(parsed.query, keep_blank_values=True)
+                if is_sensitive_query_parameter(name)
             }
             if sensitive_parameters:
                 names = ", ".join(sorted(sensitive_parameters))


### PR DESCRIPTION
## What changed

- address every actionable Copilot review finding from the merged improvement PRs
- sanitize CMS-backed teaching, software, and thesis URLs before rendering links
- reject secret-like query parameter variants, unsafe upload path components, and escaping `.pages.yml` paths
- inspect only PDF headers and add focused validator unit tests
- redesign site-wide and publication search to match the Heidelberg red design system
- use curated excerpts, improve mobile navigation handoff, add an empty state, and make Escape reliably close the dialog
- expand browser coverage across desktop, Android, and iPhone emulation

## Why

Copilot found five valid security and validation gaps in PRs #62, #83, and #76. Search worked, but its generic modal, raw excerpts, and mobile menu handoff did not fit the rest of the site.

## Impact

Pages CMS data remains unchanged. Existing pages and content stay intact; only URL rendering and validation plus search presentation and interaction change.

## Validation

- `bundle exec rake check`
- `npm run test:e2e` — 39 passed
- `bundle exec bundler-audit check`
- validator unit tests — 3 passed
- visual desktop and 390×844 mobile inspection
- no horizontal overflow or browser console errors
