### PR TITLE
Document Search Console and root-site recovery

### DIFF
--- a/docs/search-visibility.md
+++ b/docs/search-visibility.md
@@ -7,15 +7,73 @@ operations require a maintainer who can sign in to the relevant webmaster tools.
 
 1. Open Google Search Console and select or create the URL-prefix property
    `https://arith-geom.github.io/ag-comp-arith-geom/`.
-2. Ownership can be verified by the existing HTML verification file if it matches
-   the Google account managing the property. Do not replace that file without
-   checking the property's verification method.
-3. Submit
-   `https://arith-geom.github.io/ag-comp-arith-geom/sitemap.xml` under **Sitemaps**.
+   Protocol, path, and the trailing slash are part of a URL-prefix property; a
+   property for `http://`, `https://arith-geom.github.io/`, or a path without the
+   final slash is not the same property.
+2. Ownership can be verified by the existing HTML verification file if its token
+   belongs to the Google account managing the property. Deleting a Google account
+   or its Search Console access does not remove the public file from this
+   repository, but the remaining file does not prove that a new account owns its
+   token. If Search Console supplies a new verification file, add it alongside the
+   existing file, verify the new owner, and only then remove obsolete tokens.
+3. Open **Sitemaps** for that exact property. When Search Console already displays
+   the property prefix before the input, enter only `sitemap.xml`. If the interface
+   requests a full URL, submit
+   `https://arith-geom.github.io/ag-comp-arith-geom/sitemap.xml`.
 4. After favicon or important metadata deployments, inspect the homepage URL and
    request indexing. Google controls recrawl timing, so an icon change is not
    immediate.
 5. Review **Page indexing**, **Core Web Vitals**, and **HTTPS** after deployment.
+
+### If Search Console says the sitemap could not be fetched
+
+1. Open the sitemap URL in a private browser window. It must return XML rather
+   than a GitHub 404 page or HTML.
+2. In **URL inspection**, inspect the full sitemap URL and run **Test live URL**.
+3. Confirm that the selected property is exactly
+   `https://arith-geom.github.io/ag-comp-arith-geom/` and that the submitted row
+   contains the same prefix only once.
+4. Delete only the failed sitemap submission from Search Console and submit it
+   again as described above. This does not delete the sitemap or website content.
+5. If the live test succeeds but the report still says **Couldn't fetch**, wait
+   before resubmitting; Search Console can retain a temporary fetch failure.
+
+The public sitemap currently returns HTTP 200, is valid XML, is advertised from
+`robots.txt`, and contains only canonical URLs inside the project property. The
+repository therefore should not be changed merely to work around a stale Search
+Console status.
+
+## Hostname root property and Google favicon
+
+The project is hosted below `/ag-comp-arith-geom/`. The organization-wide root
+`https://arith-geom.github.io/` is a separate GitHub Pages site and requires a
+public repository named exactly `arith-geom.github.io` in the `arith-geom`
+organization. An organization owner must create that repository or grant the
+required repository-creation permission; a regular organization member cannot
+assume that authority.
+
+After the root repository exists:
+
+1. publish a small root `index.html` that links or redirects visitors to the
+   project site;
+2. publish the approved favicon at `/favicon.ico` and, preferably, matching PNG
+   and Apple touch icon variants;
+3. add the root URL-prefix property `https://arith-geom.github.io/` to Search
+   Console and place its newly issued verification file at the repository root;
+4. verify ownership before removing any older verification file; and
+5. inspect the root and project homepages and request indexing after deployment.
+
+A Domain property for `github.io` is not appropriate because the organization
+does not control GitHub's DNS zone. Use the two exact URL-prefix properties, or
+move the site to a custom domain whose DNS the organization controls.
+
+## Preserve historical file URLs
+
+Some files under `assets/img/fileadmin/` are byte-identical to migrated copies but
+their old public URLs are indexed and cited by external academic publications.
+Treat these files as compatibility aliases, not disposable duplicates. Remove one
+only with evidence that the old URL has no external consumers and with a working
+replacement or redirect strategy.
 
 ## Deployment checks
 


### PR DESCRIPTION
## What changed

- document the exact URL-prefix property and sitemap submission format
- add a safe troubleshooting sequence for Search Console fetch failures
- explain verification-token handling after account or access changes
- document the separate root Pages repository needed for hostname ownership and favicon discovery
- preserve externally indexed and cited historical asset URLs

## Why

The live sitemap is valid and fetchable by Googlebot, so changing generated content would not solve the reported Search Console status. The failure is most likely property or submission state. The root hostname currently has no Pages repository.

## Validation

- `bundle exec rake check`
- `bundle exec bundler-audit check --update`
- `npm run test:e2e` (39 passed)
- live sitemap HTTP/XML/Googlebot checks
